### PR TITLE
Remove Linux support from the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@
 
 * Extremely lightweight
 * Simple [`fs.watch`](https://nodejs.org/api/fs.html#fs_fs_watch_filename_options_listener) wrapper<sup>†</sup>
-* Runs on OSX, Linux, and Windows
+* Runs on OSX and Windows
 * Recursively monitors all subdirectories
 * Optional ignore patterns
 


### PR DESCRIPTION
`fs.watch` does not support the `recursive` option on Linux, hence the tool won't work on it.

See https://nodejs.org/api/fs.html#fs_caveats