### PR TITLE
Fix options.cwd

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ async function setup(dir, onChange) {
 }
 
 export async function watch(list, callback, opts={}) {
-	const cwd = resolve('.', opts.cwd);
+	const cwd = resolve('.', opts.cwd || '.');
 	const dirs = new Set(list.map(str => resolve(cwd, str)).filter(existsSync));
 	const ignores = ['node_modules'].concat(opts.ignore || []).map(x => new RegExp(x, 'i'));
 


### PR DESCRIPTION
Currently fails because of path.resolve('.', undefined)